### PR TITLE
Adding a lower bound of zero to confidence interval plotting

### DIFF
--- a/benford/benford.py
+++ b/benford/benford.py
@@ -980,7 +980,8 @@ def _plot_dig_(df, x, y_Exp, y_Found, N, figsize, conf_Z, text_x=False):
     if conf_Z is not None:
         sig = conf_Z * np.sqrt(y_Exp * (1 - y_Exp) / N)
         upper = y_Exp + sig + (1 / (2 * N))
-        lower = y_Exp - sig - (1 / (2 * N))
+        lower_zeros = np.array([0]*len(upper))
+        lower = np.maximum(y_Exp - sig - (1 / (2 * N)), lower_zeros)
         u = (y_Found < lower) | (y_Found > upper)
         for i, b in enumerate(bars):
             if u.iloc[i]:


### PR DESCRIPTION
Aggressive confidence intervals will cause the plotting to extend beyond the x-axis, making the plots less readable. Here's an example before and after using the first three digits of Bitcoin close [prices](https://www.coindesk.com/price/) and a 99.99999% CI:

![before](https://user-images.githubusercontent.com/7925800/40018937-030f1562-577b-11e8-9765-b13e7bf838d6.png)
![after](https://user-images.githubusercontent.com/7925800/40018939-03208450-577b-11e8-81cf-831d563045aa.png)
